### PR TITLE
Added ability to customize

### DIFF
--- a/gnome_shell_pomodoro.json
+++ b/gnome_shell_pomodoro.json
@@ -2,12 +2,14 @@
     "version": "0.1",
     "timer": 
     {
-        "pomodoro_duration": 10,
-        "short_pause_duration": 3,
-        "long_pause_duration": 6
+        "pomodoro_duration": 1500,
+        "short_pause_duration": 300,
+        "long_pause_duration": 900
     },
     "ui":
     {
+        "show_messages": true,
+        "show_elapsed_time": true,
         "key_toggle_timer": "<Ctrl><Alt>P"
     }
 }


### PR DESCRIPTION
1. Added options to the popup menu to allow:
   - switch timer display between remaining time and elapsed time
   - reset counters and timer
   - switch off notifications 
   - adjust duration of pomodoro and breaks
2. Fixed timer (was counting an additional second for every session/break)
3. Also, session counter is not lost after every 4 sessions.

![Screenshot-1](http://i.imgur.com/X56gk.png)
![Screenshot-2](http://i.imgur.com/9cGNM.png)
