### PR TITLE
Remove user-triggered notifications

### DIFF
--- a/pomodoro@arun.codito.in/extension.js
+++ b/pomodoro@arun.codito.in/extension.js
@@ -210,7 +210,6 @@ Indicator.prototype = {
             this._stopTimer = true;
             this._isPause = false;
         }
-        this._notifyUser('Pomodoro reset!', 'Stopped');
         this._timer.set_text("[" + this._sessionCount + "] --:--");
         this._widget.setToggleState(false);
         return false;
@@ -233,13 +232,11 @@ Indicator.prototype = {
     _toggleTimerState: function(item) {
         this._stopTimer = item.state;
         if (this._stopTimer == false) {
-            this._notifyUser('Pomodoro stopped!', 'Stopped');
             this._stopTimer = true;
             this._isPause = false;
             this._timer.set_text("[" + this._sessionCount + "] --:--");
         }
         else {
-            this._notifyUser('Pomodoro started!', 'Running');
             this._timeSpent = -1;
             this._minutes = 0;
             this._seconds = 0;


### PR DESCRIPTION
I had expected this to require a little more work when I opened issue #16 but the user-triggered and timer-triggered events are nicely separated - so it's as easy as just removing the 3 notifyUser calls.

I realise that this is just subjective and opinionated, so I understand if you _wontfix_ it and tell me to go away ;)
