### PR TITLE
Changed character width so that it fits on Ubuntu.

### DIFF
--- a/pomodoro@arun.codito.in/extension.js
+++ b/pomodoro@arun.codito.in/extension.js
@@ -279,7 +279,7 @@ Indicator.prototype = {
         let char_width = metrics.get_approximate_char_width() / Pango.SCALE;
 
         // predict by the number of characters and digits we have in the label
-        actor.width = parseInt(digit_width * 6 + 2.4 * char_width);
+        actor.width = parseInt(digit_width * 6 + 2.8 * char_width);
     },
 
     // Handles option changes in the UI, saves the configuration


### PR DESCRIPTION
On all Ubuntu installations I've done this far the title looks something like this: http://i.imgur.com/LmrER.png

This small change fixes it and hopefully doesn't make the label too wide in Fedora which I'm assuming is what you're using.
