### PR TITLE
Patch for French translation file

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -134,8 +134,8 @@ msgid "Start a new pomodoro"
 msgstr "Démarrer un nouveau pomodoro"
 
 #: ../src/timer.js:446
-msgid "Show dialog"
 #, fuzzy
+msgid "Show dialog"
 msgstr "Afficher la boîte de dialogue"
 
 #: ../src/timer.js:514


### PR DESCRIPTION
Hi, 

I've noticed, that the French translation sent fails to compile.  The comment between msgid and msgstr causes parsing to fail with the following error:

Making all in po
make[1]: Entering directory `/tmp/gnome-shell-pomodoro/po'
  MSGFMT fr.gmo
fr.po:137: missing`msgstr' section
fr.po:139:7: syntax error
/usr/bin/gmsgfmt: found 2 fatal errors

Attaching a fix for this.
