### PR TITLE
Fix missing semi-colon in desktop file

### DIFF
--- a/data/gnome-pomodoro.desktop.in
+++ b/data/gnome-pomodoro.desktop.in
@@ -8,6 +8,6 @@ Icon=gnome-pomodoro
 StartupNotify=true
 Terminal=false
 Type=Application
-Categories=GNOME;GTK;Accessories;
+Categories=GNOME;GTK;Utility;
 OnlyShowIn=GNOME;
 NoDisplay=true


### PR DESCRIPTION
When packaging the latest version of this project for Fedora, I get the following errors when validating the desktop file:

```
+ desktop-file-validate /home/mbooth/rpmbuild/BUILDROOT/gnome-shell-extension-pomodoro-0.10.0-1.fc20.x86_64//usr/share/applications/gnome-pomodoro.desktop
/home/mbooth/rpmbuild/BUILDROOT/gnome-shell-extension-pomodoro-0.10.0-1.fc20.x86_64//usr/share/applications/gnome-pomodoro.desktop: error: value "GNOME;GTK;Accessories" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
/home/mbooth/rpmbuild/BUILDROOT/gnome-shell-extension-pomodoro-0.10.0-1.fc20.x86_64//usr/share/applications/gnome-pomodoro.desktop: error: value "GNOME;GTK;Accessories;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Accessories"; values extending the format should start with "X-"
```

This pull request simply adds in the missing semi-colon and since "Accessories" is not a registered main category, I have changed it to "Utility" which is synonymous with "Accessories." Please see the desktop entry specification for information about the registered main categories:

http://standards.freedesktop.org/menu-spec/latest/apa.html#main-category-registry
