### PR TITLE
Added missing dependency libgstreamer0.10-dev for Ubuntu setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Look for packages named *gnome-shell-pomodoro* or *gnome-shell-extension-pomodor
 
    **On Ubuntu:**
 
-        sudo apt-get install gnome-common intltool valac libglib2.0-dev gobject-introspection libgirepository1.0-dev libgtk-3-dev libclutter-gtk-1.0-dev libgnome-desktop-3-dev libcanberra-dev libgdata-dev libgstreamer1.0-dev libupower-glib-dev fonts-droid
+        sudo apt-get install gnome-common intltool valac libglib2.0-dev gobject-introspection libgirepository1.0-dev libgtk-3-dev libclutter-gtk-1.0-dev libgnome-desktop-3-dev libcanberra-dev libgdata-dev libgstreamer1.0-dev libupower-glib-dev fonts-droid libgstreamer0.10-dev
 
    **On Fedora:**
 
@@ -122,7 +122,7 @@ Thanks to our [GitHub contributors](https://github.com/codito/gnome-shell-pomodo
 
 * Support for GNOME Shell 3.10
 * New layout in preferences dialog
-* Migrate to gsteramer-1.0
+* Migrate to gstreamer-1.0
 * Updated translations
 
 **Version 0.9.1**


### PR DESCRIPTION
Unable to build if libgstreamer0.10-dev is not installed:

configure: error: Package requirements (
    glib-2.0 >= 2.36.1
    gtk+-3.0 >= 3.8.0
    gio-2.0 >= 2.36.1
    gio-unix-2.0 >= 2.36.1
    dbus-glib-1
    gnome-desktop-3.0 >= 3.8.0
    gthread-2.0 >= 2.36.1
    gmodule-no-export-2.0 >= 2.36.1
    gsettings-desktop-schemas >= 3.8.0
    upower-glib >= 0.9.20
    libcanberra >= 0.30
    gstreamer-0.10 >= 0.10
) were not met:

_No package 'gstreamer-0.10' found_
