### PR TITLE
No more submodule to refresh on this branch.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -18,6 +18,4 @@ which gnome-autogen.sh || {
     exit 1
 }
 
-git submodule update --init --recursive
-
 REQUIRED_AUTOMAKE_VERSION=1.9 . gnome-autogen.sh


### PR DESCRIPTION
Hi,

Just a tiny change to ensure git submodule call is not done anymore in gnome-3.12 branch as you already did in the master branch.

Joseph
