### PR TITLE
Removing unreachable code that generates compilation warning.

### DIFF
--- a/src/widgets.vala
+++ b/src/widgets.vala
@@ -671,8 +671,6 @@ public class Pomodoro.SoundChooserButton : Gtk.Box
         }
 
         assert_not_reached ();
-
-        return -1;
     }
 
     private static int model_sort_func (Gtk.TreeModel model, Gtk.TreeIter a, Gtk.TreeIter b)


### PR DESCRIPTION
Hi,

As the "assert_not_reached" function should terminate the application when reached, there's no need to use a "return -1" after that. In fact, adding this generates a compilation warning:

```
widgets.vala:675.9-675.18: warning: unreachable code detected
        return -1;
        ^^^^^^^^^^
```

So I propose to remove it.
Only tested with gnome-3.12 branch but I assume we could also remove it from master.

Best,
Joseph
