### PR TITLE
Cleanup some compilation warnings

### DIFF
--- a/lib/gnome-desktop-module.vala
+++ b/lib/gnome-desktop-module.vala
@@ -133,7 +133,7 @@ public class Pomodoro.GnomeDesktopModule : Pomodoro.Module
         this.timer = timer;
     }
 
-    public static bool can_enable () {
+    public new static bool can_enable () {
         var desktop_session = GLib.Environment.get_variable
                                        (DESKTOP_SESSION_ENV_VARIABLE);
 

--- a/lib/presence-module.vala
+++ b/lib/presence-module.vala
@@ -137,7 +137,7 @@ public class Pomodoro.PresenceModule : Pomodoro.Module
             {
                 var status = presence_plugin.get_default_status (Pomodoro.State.NULL);
 
-                presence_plugin.set_status (status);
+                presence_plugin.set_status.begin (status);
             }
 
             plugin.disable ();

--- a/lib/timer.vala
+++ b/lib/timer.vala
@@ -310,7 +310,6 @@ public class Pomodoro.Timer : Object
         var state_tmp = this._state;
         var state_duration_tmp = this.state_duration;
         var elapsed_tmp = this.elapsed;
-        var session_tmp = this.session;
 
         var changed = this.do_set_state_full (state, duration, timestamp);
 

--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -198,8 +198,6 @@ class Pomodoro.TestRunner : Object
         this.setup_settings ();
     }
 
-    private bool is_setup = false;
-
     public virtual void global_teardown ()
     {
         if (this.tmp_dir != null) {


### PR DESCRIPTION
Hi Kamil,

Some of the compilations warning I noticed seemed pretty harmless and easy to fix so I pushed this PR.
It fixes:
```
gnome-desktop-module.vala:136.5-136.33: warning: Pomodoro.GnomeDesktopModule.can_enable hides inherited method `Pomodoro.Module.can_enable'. Use the `new' keyword if hiding was intentional
    public static bool can_enable () {
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```
presence-module.vala:140.17-140.42: warning: implicit .begin is deprecated
```

```
telepathy-plugin.vala:65.17-67.55: warning: local variable `current_status' declared but never used
timer.vala:313.13-313.38: warning: local variable `session_tmp' declared but never used
        var session_tmp = this.session;
            ^^^^^^^^^^^^^^^^^^^^^^^^^^
```

```
tests.vala:201.5-201.25: warning: field `Pomodoro.TestRunner.is_setup' never used
    private bool is_setup = false;
    ^^^^^^^^^^^^^^^^^^^^^
```

Pushed on gnome-3.20 as it's the one I was working from.

Feel free to comment even if it's to say you don't like! ;)
Thanks
Joseph