### PR TITLE
Adding autoconf-archive as dependency to avoid issues

### DIFF
--- a/packages/debian/debian/control.in
+++ b/packages/debian/debian/control.in
@@ -2,7 +2,8 @@ Source: @PACKAGE_NAME@
 Maintainer: Kamil Prusko <kamilprusko@gmail.com>
 Section: gnome
 Priority: optional
-Build-Depends: debhelper (>= 9.0.0),
+Build-Depends: autoconf-archive,
+               debhelper (>= 9.0.0),
                dh-autoreconf,
                gettext,
                valac (>= @VALA_REQUIRED@),

--- a/packages/debian/gnome-pomodoro.dsc.in
+++ b/packages/debian/gnome-pomodoro.dsc.in
@@ -6,4 +6,4 @@ Maintainer: Kamil Prusko <kamilprusko@gmail.com>
 Homepage: @PACKAGE_URL@
 Architecture: any
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9.0.0), dh-autoreconf, gettext, valac (>= @VALA_REQUIRED@), pkg-config, desktop-file-utils, appstream-util, libglib2.0-dev (>= @GLIB_REQUIRED@), gsettings-desktop-schemas-dev (>= @GNOME_REQUIRED@), gobject-introspection (>= @INTROSPECTION_REQUIRED@), libgirepository1.0-dev, libgstreamer1.0-dev (>= 1.2.0), libgtk-3-dev (>= @GTK_REQUIRED@), libcanberra-dev (>= 0.30), libpeas-dev (>= @LIBPEAS_REQUIRED@), libappindicator3-dev
+Build-Depends: debhelper (>= 9.0.0), dh-autoreconf, gettext, valac (>= @VALA_REQUIRED@), pkg-config, desktop-file-utils, appstream-util, libglib2.0-dev (>= @GLIB_REQUIRED@), gsettings-desktop-schemas-dev (>= @GNOME_REQUIRED@), gobject-introspection (>= @INTROSPECTION_REQUIRED@), libgirepository1.0-dev, libgstreamer1.0-dev (>= 1.2.0), libgtk-3-dev (>= @GTK_REQUIRED@), libcanberra-dev (>= 0.30), libpeas-dev (>= @LIBPEAS_REQUIRED@), libappindicator3-dev, autoconf-archive


### PR DESCRIPTION
Hi,

In commit a11a8e4 you added `AX_IS_RELEASE([git-directory])` but this requires the `autoconf-archive` package which is not always present in minimal environment (faced the issue when preparing the new release for Debian).
This commit adds them to your debian files.

Joseph