### PR TITLE
Re-enable the tests for the debian package

### DIFF
--- a/packages/debian/debian/control.in
+++ b/packages/debian/debian/control.in
@@ -18,7 +18,9 @@ Build-Depends: autoconf-archive,
                libgtk-3-dev (>= @GTK_REQUIRED@),
                libcanberra-dev (>= 0.30),
                libpeas-dev (>= @LIBPEAS_REQUIRED@),
-               libappindicator3-dev
+               libappindicator3-dev,
+               xauth,
+               xvfb
 Standards-Version: 3.9.6
 Homepage: @PACKAGE_URL@
 

--- a/packages/debian/debian/rules.in
+++ b/packages/debian/debian/rules.in
@@ -10,6 +10,8 @@ override_dh_autoreconf:
 	dh_autoreconf ./autogen.sh -- --prefix=@prefix@ --datadir=@datadir@
 
 override_dh_auto_test:
+	# tests require an X server
+	xvfb-run -a dh_auto_test
 
 
 postinst:


### PR DESCRIPTION
Good morning @kamilprusko ! :)

This PR re-enable tests on the debian package build.
It adds a minimal x server to make it work.
Note: I've made a few changes (debhelpers version bump and standards bump along with the change of target folder for the *.appdata.xml file - see https://wiki.debian.org/AppStream/Guidelines for more informations).
You might want to look at the latest commits on: https://anonscm.debian.org/cgit/collab-maint/gnome-shell-pomodoro.git for more details if you're interested.
Thanks
Joseph
