### PR TITLE
Fix minor typo proccess -> process

### DIFF
--- a/lib/application.vala
+++ b/lib/application.vala
@@ -415,7 +415,7 @@ namespace Pomodoro
                                           null);
             }
             catch (GLib.SpawnError error) {
-                GLib.warning ("Failed to spawn proccess: %s", error.message);
+                GLib.warning ("Failed to spawn process: %s", error.message);
             }
         }
 
@@ -434,7 +434,7 @@ namespace Pomodoro
                                           null);
             }
             catch (GLib.SpawnError error) {
-                GLib.warning ("Failed to spawn proccess: %s", error.message);
+                GLib.warning ("Failed to spawn process: %s", error.message);
             }
         }
 


### PR DESCRIPTION
Hi Kamil,

Lintian noticed a minor typo in a message (2 c in process). This PR fixes that.

Best,
Joseph
