### PR TITLE
Remove usage of metascreen to make it work with gnome-shell 3.29 and up

### DIFF
--- a/plugins/gnome/extension/dialogs.js
+++ b/plugins/gnome/extension/dialogs.js
@@ -354,7 +354,10 @@ var ModalDialog = new Lang.Class({
                         this._onPushModalDelayTimeout.bind(this));
         }
 
-        this._monitorConstraint.index = global.screen.get_primary_monitor();
+        if (global.screen)
+            this._monitorConstraint.index = global.screen.get_current_monitor() // mutter < 3.29
+        else
+            this._monitorConstraint.index = global.display.get_current_monitor() // mutter >= 3.29
 
         this.actor.raise_top();
         this.actor.show();


### PR DESCRIPTION
Closes #365 
Also keeps compatibility with previous versions.

@kamilprusko should I duplicate that PR on gnome-3.26? It seems to have diverged a bit from master last year.
Note: Tested, it works fine. I'm including that patch in the next Debian release.

Thanks,
Joseph