### PR TITLE
Switch from the deprecated Ubuntu libappindicator to the maintained libayatana-appindicator

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ PKG_CHECK_MODULES(GNOME_PLUGIN, [
 ], [with_gnome_plugin=yes], [with_gnome_plugin=no])
 
 PKG_CHECK_MODULES(INDICATOR_PLUGIN, [
-    appindicator3-0.1
+    ayatana-appindicator3-0.1
 ], [with_indicator_plugin=yes], [with_indicator_plugin=no])
 
 # Checks for programs.

--- a/packages/debian/debian/control.in
+++ b/packages/debian/debian/control.in
@@ -20,7 +20,7 @@ Build-Depends: autoconf-archive,
                libcanberra-dev (>= 0.30),
                libpeas-dev (>= @LIBPEAS_REQUIRED@),
                libgom-1.0-dev,
-               libappindicator3-dev
+               libayatana-appindicator3-dev
 Standards-Version: 3.9.6
 Homepage: @PACKAGE_URL@
 

--- a/packages/debian/gnome-pomodoro.dsc.in
+++ b/packages/debian/gnome-pomodoro.dsc.in
@@ -6,4 +6,4 @@ Maintainer: Kamil Prusko <kamilprusko@gmail.com>
 Homepage: @PACKAGE_URL@
 Architecture: any
 Standards-Version: 3.9.6
-Build-Depends: debhelper (>= 9.0.0), dh-autoreconf, gettext, valac (>= @VALA_REQUIRED@), pkg-config, desktop-file-utils, appstream-util, libappstream-glib-dev, libglib2.0-dev (>= @GLIB_REQUIRED@), gsettings-desktop-schemas-dev (>= @GNOME_REQUIRED@), gobject-introspection (>= @INTROSPECTION_REQUIRED@), libgirepository1.0-dev, libgstreamer1.0-dev (>= 1.2.0), libgtk-3-dev (>= @GTK_REQUIRED@), libcanberra-dev (>= 0.30), libpeas-dev (>= @LIBPEAS_REQUIRED@), libgom-1.0-dev, libappindicator3-dev, autoconf-archive
+Build-Depends: debhelper (>= 9.0.0), dh-autoreconf, gettext, valac (>= @VALA_REQUIRED@), pkg-config, desktop-file-utils, appstream-util, libappstream-glib-dev, libglib2.0-dev (>= @GLIB_REQUIRED@), gsettings-desktop-schemas-dev (>= @GNOME_REQUIRED@), gobject-introspection (>= @INTROSPECTION_REQUIRED@), libgirepository1.0-dev, libgstreamer1.0-dev (>= 1.2.0), libgtk-3-dev (>= @GTK_REQUIRED@), libcanberra-dev (>= 0.30), libpeas-dev (>= @LIBPEAS_REQUIRED@), libgom-1.0-dev, libayatana-appindicator3-dev, autoconf-archive

--- a/plugins/indicator/Makefile.am
+++ b/plugins/indicator/Makefile.am
@@ -19,7 +19,7 @@ libindicator_la_SOURCES = \
 
 libindicator_la_VALAFLAGS = \
 	$(PLUGIN_VALAFLAGS) \
-	--pkg appindicator3-0.1
+	--pkg ayatana-appindicator3-0.1
 
 libindicator_la_CPPFLAGS = \
 	$(PLUGIN_CPPFLAGS) \


### PR DESCRIPTION
Closes: #353
@kamilprusko should I duplicate that PR on gnome-3.26? It seems to have diverged a bit from master last year.
Note: Tested, it works fine. I'm including that patch in the next Debian release.

Thanks,
Joseph