### PR TITLE
default is not allowed on custom get accessors with Vala 0.42.0

### DIFF
--- a/plugins/sounds/sound-player.vala
+++ b/plugins/sounds/sound-player.vala
@@ -119,22 +119,28 @@ namespace SoundsPlugin
 
         public double volume {
             get {
-                return this.pipeline.volume;
+                if (this.pipeline != null && this.pipeline.volume != null) {
+                    return this.pipeline.volume;
+                } else {
+                    return 1.0;
+                }
             }
             set {
                 this.pipeline.volume = value.clamp (0.0, 1.0);
             }
-            default = 1.0;
         }
 
         public double volume_fade {
             get {
-                return this.volume_filter.volume;
+                if (this.volume_filter != null && this.volume_filter.volume != null) {
+                    return this.volume_filter.volume;
+                } else {
+                    return 0.0;
+                }
             }
             set {
                 this.volume_filter.volume = value.clamp (0.0, 1.0);
             }
-            default = 0.0;
         }
 
         public bool repeat { get; set; default = false; }


### PR DESCRIPTION
Closes: #369 
@kamilprusko should I duplicate that PR on gnome-3.26? It seems to have diverged a bit from master last year.
Note: Tested, it works fine. I'm including that patch in the next Debian release.

Thanks,
Joseph