### PR TITLE
Fix build for Gnome 3.32 using Vala 0.44.1

### DIFF
--- a/lib/application.vala
+++ b/lib/application.vala
@@ -66,7 +66,7 @@ namespace Pomodoro
             FAILURE   =  1
         }
 
-        private struct Options
+        private class Options
         {
             public static bool no_default_window = false;
             public static bool preferences = false;
@@ -146,7 +146,7 @@ namespace Pomodoro
 
         public unowned Gtk.Window get_last_focused_window ()
         {
-            unowned List<weak Gtk.Window> windows = this.get_windows ();
+            unowned List<Gtk.Window> windows = this.get_windows ();
 
             return windows != null
                     ? windows.first ().data


### PR DESCRIPTION
Build fix for #402 
This will not fix Gnome Shell 3.32 runtime errors.