### PR TITLE
Changed "Public" to "Protected" due to compilation error when method …

### DIFF
--- a/tests/tests.vala
+++ b/tests/tests.vala
@@ -70,7 +70,7 @@ namespace Pomodoro
         private GLib.TestSuite g_test_suite;
         private TestSuiteAdaptor[] adaptors = new TestSuiteAdaptor[0];
 
-        public TestSuite () {
+        protected TestSuite () {
             var name = this.get_name ();
             this.g_test_suite = new GLib.TestSuite (name);
         }


### PR DESCRIPTION
…is public inside abstract class.