### PR TITLE
Partial support for gnome shell 3.37.90

### DIFF
--- a/plugins/gnome/extension/dialogs.js
+++ b/plugins/gnome/extension/dialogs.js
@@ -32,7 +32,6 @@ const GrabHelper = imports.ui.grabHelper;
 const Layout = imports.ui.layout;
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
 
 const Params = imports.misc.params;
 
@@ -392,23 +391,23 @@ var ModalDialog = class {
         global.stage.set_child_above_sibling(this.actor, null);
         this.actor.show();
 
-        Tweener.removeTweens(this.actor);
+        this.actor.remove_all_transitions();
 
         this._addMessageTray();
 
         if (animate) {
             this._lightbox.lightOn(FADE_IN_TIME);
-            Tweener.addTween(this.actor,
-                             { opacity: 255,
-                               time: FADE_IN_TIME / 1000,
-                               transition: 'easeOutQuad',
-                               onComplete: () => {
-                                   if (this.state == State.OPENING) {
-                                       this.state = State.OPENED;
-                                       this.emit('opened');
-                                   }
-                               }
-                             });
+            this.actor.ease({
+                opacity: 255,
+                duration: FADE_IN_TIME,
+                mode: Clutter.Animation.EASE_OUT_QUAD,
+                onComplete: () => {
+                    if (this.state == State.OPENING) {
+                        this.state = State.OPENED;
+                        this.emit('opened');
+		    }
+                }
+            });
             this.emit('opening');
         }
         else {
@@ -432,25 +431,25 @@ var ModalDialog = class {
         this.state = State.CLOSING;
         this.popModal();
 
-        Tweener.removeTweens(this.actor);
+        this.actor.remove_all_transitions();
 
         if (animate) {
             this._lightbox.lightOff(FADE_OUT_TIME);
-            Tweener.addTween(this.actor,
-                             { opacity: 0,
-                               time: FADE_OUT_TIME / 1000,
-                               transition: 'easeOutQuad',
-                               onComplete: () => {
-                                   if (this.state == State.CLOSING) {
-                                       this.state = State.CLOSED;
-                                       this.actor.hide();
+            this.actor.ease({
+                opacity: 0,
+                duration: FADE_OUT_TIME,
+                mode: Clutter.Animation.EASE_OUT_QUAD,
+                onComplete: () => {
+                    if (this.state == State.CLOSING) {
+                        this.state = State.CLOSED;
+                        this.actor.hide();
 
-                                       this._removeMessageTray();
+                        this._removeMessageTray();
 
-                                       this.emit('closed');
-                                   }
-                               }
-                             });
+                        this.emit('closed');
+		    }
+                }
+            });
             this.emit('closing');
         }
         else {

--- a/plugins/gnome/extension/indicator.js
+++ b/plugins/gnome/extension/indicator.js
@@ -36,7 +36,6 @@ const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
 
 const Config = Extension.imports.config;
 const Timer = Extension.imports.timer;
@@ -384,16 +383,18 @@ var TextIndicator = class {
             this._state = state;
 
             if (state == Timer.State.POMODORO) {
-                Tweener.addTween(this.actor,
-                                 { opacity: FADE_IN_OPACITY * 255,
-                                   time: FADE_IN_TIME / 1000,
-                                   transition: 'easeOutQuad' });
+                this.actor.ease({
+                    opacity: FADE_IN_OPACITY * 255,
+                    duration: FADE_IN_TIME,
+                    mode: Clutter.AnimationMode.EASE_OUT_QUAD
+                });
             }
             else {
-                Tweener.addTween(this.actor,
-                                 { opacity: FADE_OUT_OPACITY * 255,
-                                   time: FADE_OUT_TIME / 1000,
-                                   transition: 'easeOutQuad' });
+               this.actor.ease({
+                    opacity: FADE_OUT_OPACITY * 255,
+                    duration: FADE_OUT_TIME,
+                    mode: Clutter.AnimationMode.EASE_OUT_QUAD
+               });
             }
         }
 
@@ -684,32 +685,32 @@ class PomodoroIndicator extends PanelMenu.Button {
             this._blinking = true;
 
             let fadeOutParams = {
-                time: FADE_OUT_TIME / 1000,
-                transition: 'easeInOutQuad',
+                duration: FADE_OUT_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
                 opacity: FADE_OUT_OPACITY * 255
             };
             let fadeInParams = {
-                time: FADE_IN_TIME / 1000,
-                transition: 'easeInOutQuad',
-                delay: FADE_OUT_TIME / 1000,
+                duration: FADE_IN_TIME,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+                delay: FADE_OUT_TIME,
                 opacity: FADE_IN_OPACITY * 255,
                 onComplete: this._onBlinked.bind(this)
             };
 
             if (Gtk.Settings.get_default().gtk_enable_animations) {
-                Tweener.addTween(this._hbox, fadeOutParams);
-                Tweener.addTween(this._hbox, fadeInParams);
-                Tweener.addTween(this.menu.timerLabel, fadeOutParams);
-                Tweener.addTween(this.menu.timerLabel, fadeInParams);
-                Tweener.addTween(this.menu.pauseAction.child, fadeOutParams);
-                Tweener.addTween(this.menu.pauseAction.child, fadeInParams);
+                this._hbox.ease(fadeOutParams);
+                this._hbox.ease(fadeInParams);
+                this.menu.timerLabel.ease(fadeOutParams);
+                this.menu.timerLabel.ease(fadeInParams);
+                this.menu.pauseAction.child.ease(fadeOutParams);
+                this.menu.pauseAction.child.ease(fadeInParams);
             }
             else if (this._blinkTimeoutSource == 0) {
-                Tweener.addTween(this._hbox, fadeOutParams);
+                this._hbox.ease(fadeOutParams);
 
                 this._blinkTimeoutSource = GLib.timeout_add(GLib.PRIORITY_DEFAULT, FADE_OUT_TIME,
                     () => {
-                        Tweener.addTween(this._hbox, fadeInParams);
+                        this._hbox.ease(fadeInParams);
 
                         this._blinkTimeoutSource = GLib.timeout_add(GLib.PRIORITY_DEFAULT, FADE_IN_TIME, () => {
                             this._blinkTimeoutSource = 0;
@@ -732,19 +733,19 @@ class PomodoroIndicator extends PanelMenu.Button {
     _onTimerResumed() {
         if (this._blinking) {
             let fadeInParams = {
-                time: 200 / 1000,
-                transition: 'easeOutQuad',
+                duration: 200,
+                mode: Clutter.AnimationMode.EASE_OUT_QUAD,
                 opacity: FADE_IN_OPACITY * 255,
                 onComplete: this._onBlinked.bind(this)
             };
 
-            Tweener.removeTweens(this._hbox);
-            Tweener.removeTweens(this.menu.timerLabel);
-            Tweener.removeTweens(this.menu.pauseAction.child);
+            this._hbox.remove_all_transitions();
+            this.menu.timerLabel.remove_all_transitions();
+            this.menu.pauseAction.child.remove_all_transitions();
 
-            Tweener.addTween(this._hbox, fadeInParams);
-            Tweener.addTween(this.menu.timerLabel, fadeInParams);
-            Tweener.addTween(this.menu.pauseAction.child, fadeInParams);
+            this._hbox.ease(fadeInParams);
+            this.menu.timerLabel.ease(fadeInParams);
+            this.menu.pauseAction.child.ease(fadeInParams);
 
             if (this._blinkTimeoutSource != 0) {
                 GLib.source_remove(this._blinkTimeoutSource);


### PR DESCRIPTION
This adds partial support for the latest development version of gnome shell by replacing Tweener, which was removed in gnome shell 3.37.1, with Clutter's implicit animations.

What's left that's not working is the desktop not responding to mouse clicks after first pomodoro time out.