### PR TITLE
Fix notification heads-up before pomodoro end in 3.36

### DIFF
--- a/plugins/gnome/extension/notifications.js
+++ b/plugins/gnome/extension/notifications.js
@@ -63,6 +63,14 @@ function getDefaultSource() {
     return source;
 }
 
+const PomodoroNotificationPolicy = GObject.registerClass(class PomodoroNotificationPolicy extends MessageTray.NotificationPolicy {
+    get showInLockScreen() {
+        return true;
+    }
+    get detailsInLockScreen() {
+        return true;
+    }
+});
 
 var Source = GObject.registerClass(
 class PomodoroSource extends MessageTray.Source {
@@ -107,10 +115,8 @@ class PomodoroSource extends MessageTray.Source {
         });
     }
 
-    /* override parent method */
     _createPolicy() {
-        return new MessageTray.NotificationPolicy({ showInLockScreen: true,
-                                                    detailsInLockScreen: true });
+        return new PomodoroNotificationPolicy();
     }
 
     _lastNotificationRemoved() {


### PR DESCRIPTION
Those properties have been made read-only in April 2020, subclassing is
required:
https://github.com/GNOME/gnome-shell/commit/6aa1b817c9f65bad2a9af9b772d6876e30babf03

I haven't checked it with the 3.34. It might be not backward compatible.

Fixes: #509