### PR TITLE
Set horizontal icon layout align to center

### DIFF
--- a/plugins/gnome/extension/indicator.js
+++ b/plugins/gnome/extension/indicator.js
@@ -612,6 +612,7 @@ class PomodoroIndicator extends PanelMenu.Button {
 
         this._hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box' });
         this._hbox.pack_start = true;
+        this._hbox.set_x_align(Clutter.ActorAlign.CENTER);
         this._hbox.set_y_align(Clutter.ActorAlign.CENTER);
         this._hbox.add_child(this._arrow);
         this.add_child(this._hbox);


### PR DESCRIPTION
Fix for icon position when panel is vertical (material shell / dash to panel option)
Before: https://i.imgur.com/HgifSL5.png
After: https://i.imgur.com/8rLLDGw.png