### PR TITLE
Remove Tweener (fix for GNOME 3.38)

### DIFF
--- a/plugins/gnome/extension/dialogs.js
+++ b/plugins/gnome/extension/dialogs.js
@@ -32,7 +32,6 @@ const GrabHelper = imports.ui.grabHelper;
 const Layout = imports.ui.layout;
 const Lightbox = imports.ui.lightbox;
 const Main = imports.ui.main;
-const Tweener = imports.ui.tweener;
 
 const Params = imports.misc.params;
 
@@ -392,16 +391,16 @@ var ModalDialog = class {
         global.stage.set_child_above_sibling(this.actor, null);
         this.actor.show();
 
-        Tweener.removeTweens(this.actor);
+        this.actor.remove_all_transitions();
 
         this._addMessageTray();
 
         if (animate) {
             this._lightbox.lightOn(FADE_IN_TIME);
-            Tweener.addTween(this.actor,
+            this.actor.bin.ease(
                              { opacity: 255,
                                time: FADE_IN_TIME / 1000,
-                               transition: 'easeOutQuad',
+                               transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                                onComplete: () => {
                                    if (this.state == State.OPENING) {
                                        this.state = State.OPENED;
@@ -432,14 +431,14 @@ var ModalDialog = class {
         this.state = State.CLOSING;
         this.popModal();
 
-        Tweener.removeTweens(this.actor);
+        this.actor.remove_all_transitions();
 
         if (animate) {
             this._lightbox.lightOff(FADE_OUT_TIME);
-            Tweener.addTween(this.actor,
+            this.actor.bin.ease(
                              { opacity: 0,
                                time: FADE_OUT_TIME / 1000,
-                               transition: 'easeOutQuad',
+                               transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                                onComplete: () => {
                                    if (this.state == State.CLOSING) {
                                        this.state = State.CLOSED;

--- a/plugins/gnome/extension/indicator.js
+++ b/plugins/gnome/extension/indicator.js
@@ -36,7 +36,6 @@ const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
-const Tweener = imports.ui.tweener;
 
 const Config = Extension.imports.config;
 const Timer = Extension.imports.timer;
@@ -384,16 +383,16 @@ var TextIndicator = class {
             this._state = state;
 
             if (state == Timer.State.POMODORO) {
-                Tweener.addTween(this.actor,
+                this.actor.bin.ease(
                                  { opacity: FADE_IN_OPACITY * 255,
                                    time: FADE_IN_TIME / 1000,
-                                   transition: 'easeOutQuad' });
+                                   transition:  Clutter.AnimationMode.EASE_IN_OUT_QUAD });
             }
             else {
-                Tweener.addTween(this.actor,
+                this.actor.bin.ease(
                                  { opacity: FADE_OUT_OPACITY * 255,
                                    time: FADE_OUT_TIME / 1000,
-                                   transition: 'easeOutQuad' });
+                                   transition:  Clutter.AnimationMode.EASE_IN_OUT_QUAD });
             }
         }
 
@@ -612,7 +611,6 @@ class PomodoroIndicator extends PanelMenu.Button {
 
         this._hbox = new St.BoxLayout({ style_class: 'panel-status-menu-box' });
         this._hbox.pack_start = true;
-        this._hbox.set_x_align(Clutter.ActorAlign.CENTER);
         this._hbox.set_y_align(Clutter.ActorAlign.CENTER);
         this._hbox.add_child(this._arrow);
         this.add_child(this._hbox);
@@ -686,31 +684,31 @@ class PomodoroIndicator extends PanelMenu.Button {
 
             let fadeOutParams = {
                 time: FADE_OUT_TIME / 1000,
-                transition: 'easeInOutQuad',
+                transition:  Clutter.AnimationMode.EASE_IN_OUT_QUAD,
                 opacity: FADE_OUT_OPACITY * 255
             };
             let fadeInParams = {
                 time: FADE_IN_TIME / 1000,
-                transition: 'easeInOutQuad',
+                transition:  Clutter.AnimationMode.EASE_IN_OUT_QUAD,
                 delay: FADE_OUT_TIME / 1000,
                 opacity: FADE_IN_OPACITY * 255,
                 onComplete: this._onBlinked.bind(this)
             };
 
             if (Gtk.Settings.get_default().gtk_enable_animations) {
-                Tweener.addTween(this._hbox, fadeOutParams);
-                Tweener.addTween(this._hbox, fadeInParams);
-                Tweener.addTween(this.menu.timerLabel, fadeOutParams);
-                Tweener.addTween(this.menu.timerLabel, fadeInParams);
-                Tweener.addTween(this.menu.pauseAction.child, fadeOutParams);
-                Tweener.addTween(this.menu.pauseAction.child, fadeInParams);
+                this._hbox.bin.ease( fadeOutParams);
+                this._hbox.bin.ease( fadeInParams);
+                this.menu.timerLabel.bin.ease( fadeOutParams);
+                this.menu.timerLabel.bin.ease( fadeInParams);
+                this.menu.pauseAction.child.bin.ease( fadeOutParams);
+                this.menu.pauseAction.child.bin.ease( fadeInParams);
             }
             else if (this._blinkTimeoutSource == 0) {
-                Tweener.addTween(this._hbox, fadeOutParams);
+                this._hbox.bin.ease( fadeOutParams);
 
                 this._blinkTimeoutSource = GLib.timeout_add(GLib.PRIORITY_DEFAULT, FADE_OUT_TIME,
                     () => {
-                        Tweener.addTween(this._hbox, fadeInParams);
+                        this._hbox.bin.ease( fadeInParams);
 
                         this._blinkTimeoutSource = GLib.timeout_add(GLib.PRIORITY_DEFAULT, FADE_IN_TIME, () => {
                             this._blinkTimeoutSource = 0;
@@ -734,18 +732,18 @@ class PomodoroIndicator extends PanelMenu.Button {
         if (this._blinking) {
             let fadeInParams = {
                 time: 200 / 1000,
-                transition: 'easeOutQuad',
+                transition: Clutter.AnimationMode.EASE_OUT_QUAD,
                 opacity: FADE_IN_OPACITY * 255,
                 onComplete: this._onBlinked.bind(this)
             };
 
-            Tweener.removeTweens(this._hbox);
-            Tweener.removeTweens(this.menu.timerLabel);
-            Tweener.removeTweens(this.menu.pauseAction.child);
+            this._hbox.remove_all_transitions();
+            this.menu.timerLabel.remove_all_transitions();
+            this.menu.pauseAction.child.remove_all_transitions();
 
-            Tweener.addTween(this._hbox, fadeInParams);
-            Tweener.addTween(this.menu.timerLabel, fadeInParams);
-            Tweener.addTween(this.menu.pauseAction.child, fadeInParams);
+            this._hbox.bin.ease( fadeInParams);
+            this.menu.timerLabel.bin.ease( fadeInParams);
+            this.menu.pauseAction.child.bin.ease( fadeInParams);
 
             if (this._blinkTimeoutSource != 0) {
                 GLib.source_remove(this._blinkTimeoutSource);


### PR DESCRIPTION
This removes Tweener and replaces with Clutter native animations. Fixes the extension for 3.38)